### PR TITLE
Fix embed reference

### DIFF
--- a/src/edit.tsx
+++ b/src/edit.tsx
@@ -34,7 +34,8 @@ async function initializeCurrentId(): Promise<SnipReference> {
 async function getSnipByReference(reference: SnipReference): Promise<SnipWithSource | undefined> {
     // if loading the snip fails
     // non-local embed reference - will fail
-    return getSnipById(reference).catch((error) => undefined);
+    // Happens when an embed reference is not present in the document.
+    return getSnipById(reference).catch(() => undefined);
 }
 
 /**

--- a/src/edit.tsx
+++ b/src/edit.tsx
@@ -31,6 +31,12 @@ async function initializeCurrentId(): Promise<SnipReference> {
     return reference;
 }
 
+async function getSnipByReference(reference: SnipReference): Promise<SnipWithSource | undefined> {
+    // if loading the snip fails
+    // non-local embed reference - will fail
+    return getSnipById(reference).catch((error) => undefined);
+}
+
 /**
  * The initial snip to open is the first of:
  * - The snip id from local storage
@@ -40,7 +46,7 @@ async function initializeCurrentId(): Promise<SnipReference> {
 async function getInitialSnip(): Promise<SnipWithSource> {
     const currentId = await initializeCurrentId();
     log(LogTag.Setup, "currentId - complete");
-    const initialSnip = await getSnipById(currentId);
+    const initialSnip = await getSnipByReference(currentId);
     log(LogTag.Setup, "initialSnip - complete");
 
     if (initialSnip === undefined) {


### PR DESCRIPTION
Fix issue where embed would be the last snip loaded. On a document without that embed reference it will fail. In this case fallback to last opened snip.